### PR TITLE
Fix docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -149,8 +149,8 @@ services:
             - CONTAINER_EXPIRE_SECS=3600
             - IDLE_TIMEOUT=5
 
-            - BROWSER_NET=webrecorder_browsers
-            - MAIN_NET=webrecorder_default
+            - BROWSER_NET=conifer_browsers
+            - MAIN_NET=conifer_default
 
         ports:
             - 9020:9020
@@ -223,8 +223,6 @@ services:
 networks:
     default:
         driver: bridge
-
-
     browsers:
         driver: bridge
 


### PR DESCRIPTION
Now the default directory for cloning the project is `conifer` so the name of networks created by docker-compose are `conifer_browsers` and `conifer_default`